### PR TITLE
fix: multimedia tracking crashes

### DIFF
--- a/compass/build.gradle
+++ b/compass/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'maven-publish'
 }
 
-def compassVersion = "1.7.4"
+def compassVersion = "1.7.5"
 def apiVersion = "0.1"
 android {
     compileSdk 33

--- a/compass/src/main/java/com/marfeel/compass/network/ApiClient.kt
+++ b/compass/src/main/java/com/marfeel/compass/network/ApiClient.kt
@@ -86,7 +86,7 @@ internal class ApiClient(
 			}
 
 			Result.success(null)
-		} catch (exception: IOException) {
+		} catch (exception: Exception) {
 			Result.failure(exception)
 		}
 	}


### PR DESCRIPTION
Looks like from time to time endpoint is failing/returning weird content, crashing the app because of trying to deserialize a malformedd json. As this piece of the code is not something we can say really critical, I've changed exception handling in order to catch all exceptions related with rfv.

```
Fatal Exception: rf.v: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $
       at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:270)
       at com.google.gson.Gson.fromJson(Gson.java:1058)
       at com.google.gson.Gson.fromJson(Gson.java:1016)
       at com.google.gson.Gson.fromJson(Gson.java:959)
       at com.google.gson.Gson.fromJson(Gson.java:927)
       at com.marfeel.compass.network.ApiClient.getRfv-IoAF18A(ApiClient.kt:87)
       at com.marfeel.compass.usecase.GetRFV.invoke(GetRFV.kt:30)
       at com.marfeel.compass.core.ping.MultimediaPingEmitter$ping$trackingFn$1.invoke(MultimediaPingEmitter.kt:40)
       at com.marfeel.compass.core.ping.MultimediaPingEmitter$ping$trackingFn$1.invoke(MultimediaPingEmitter.kt:39)
       at com.marfeel.compass.core.ping.MultimediaPingEmitterKt$throttle$1$1.invokeSuspend(MultimediaPingEmitter.kt:26)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
       at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
       at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
       at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.java:570)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
```