### PR TITLE
fix: do not store data if consent is false

### DIFF
--- a/app/src/main/java/com/marfeel/demoapp/MainScreen.kt
+++ b/app/src/main/java/com/marfeel/demoapp/MainScreen.kt
@@ -65,6 +65,7 @@ fun MainScreen(
 	tracker.addUserSegment("another-segment")
 	tracker.setUserConsent(true)
 	tracker.setUserType(UserType.Custom(11))
+	tracker.setUserConsent(true)
 
 	Scaffold(
 		Modifier

--- a/app/src/main/java/com/marfeel/demoapp/RecyclerViewActivity.kt
+++ b/app/src/main/java/com/marfeel/demoapp/RecyclerViewActivity.kt
@@ -30,5 +30,6 @@ class RecyclerViewActivity : AppCompatActivity() {
 		recyclerview.adapter = adapter
 
 		tracker.trackNewPage("https://newsactivityxml-recycler-view.com", recyclerview)
+		tracker.setUserConsent(false)
 	}
 }

--- a/compass/build.gradle
+++ b/compass/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'maven-publish'
 }
 
-def compassVersion = "1.9.0"
+def compassVersion = "1.10.0"
 def apiVersion = "0.1"
 android {
     compileSdk 33

--- a/compass/src/main/java/com/marfeel/compass/storage/SharedPreferencesMock.kt
+++ b/compass/src/main/java/com/marfeel/compass/storage/SharedPreferencesMock.kt
@@ -1,0 +1,132 @@
+package com.marfeel.compass.storage
+import android.content.SharedPreferences
+import android.content.SharedPreferences.OnSharedPreferenceChangeListener
+import java.util.HashMap
+import kotlin.collections.set
+
+/**
+ * Mock implementation of [SharedPreferences], which just saves data in memory using map.
+ */
+@Suppress("UNCHECKED_CAST")
+internal class MockSharedPreference : SharedPreferences {
+
+    var preferenceMap = HashMap<String, Any>()
+
+    var uncommittedPreferenceMap = HashMap<String, Any>()
+
+    private val preferenceEditor: MockSharedPreferenceEditor =
+        MockSharedPreferenceEditor(preferenceMap, uncommittedPreferenceMap)
+
+    private var listeners: MutableSet<OnSharedPreferenceChangeListener> = HashSet()
+
+    override fun getAll(): Map<String, *> = preferenceMap
+
+    override fun getString(key: String, defaultValue: String?): String? =
+        preferenceMap.getOrDefault(key, defaultValue) as String?
+
+    override fun getStringSet(key: String, defaultValue: Set<String>?): Set<String>? =
+        preferenceMap.getOrDefault(key, defaultValue) as Set<String>?
+
+    override fun getInt(key: String, defaultValue: Int): Int =
+        preferenceMap[key] as Int? ?: defaultValue;
+
+    override fun getLong(key: String, defaultValue: Long): Long =
+        preferenceMap[key] as Long? ?: defaultValue;
+
+    override fun getFloat(key: String, defaultValue: Float): Float =
+        preferenceMap[key] as Float? ?: defaultValue;
+
+    override fun getBoolean(key: String, defaultValue: Boolean): Boolean =
+        preferenceMap[key] as Boolean? ?: defaultValue;
+
+    override fun contains(key: String): Boolean =
+        key in preferenceMap
+
+    override fun edit(): SharedPreferences.Editor = preferenceEditor
+
+    override fun registerOnSharedPreferenceChangeListener(listener: OnSharedPreferenceChangeListener) {
+        listeners.add(listener)
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(listener: OnSharedPreferenceChangeListener) {
+        listeners.remove(listener)
+    }
+
+    class MockSharedPreferenceEditor(
+        private val preferenceMap: MutableMap<String, Any>,
+        private val uncommittedPreferenceMap: MutableMap<String, Any>,
+        private var uncommittedRemoveKeys: MutableList<String> = ArrayList()
+    ) : SharedPreferences.Editor {
+
+        override fun putString(key: String, value: String?): SharedPreferences.Editor {
+            if (value == null) {
+                uncommittedPreferenceMap.remove(key)
+            } else {
+                uncommittedPreferenceMap[key] = value
+            }
+
+            return this
+        }
+
+        override fun putStringSet(key: String, value: Set<String>?): SharedPreferences.Editor {
+            if (value == null) {
+                uncommittedPreferenceMap.remove(key)
+            } else {
+                uncommittedPreferenceMap[key] = value
+            }
+
+            return this
+        }
+
+        override fun putInt(key: String, value: Int): SharedPreferences.Editor {
+            uncommittedPreferenceMap[key] = value
+            return this
+        }
+
+        override fun putLong(key: String, value: Long): SharedPreferences.Editor {
+            uncommittedPreferenceMap[key] = value
+            return this
+        }
+
+        override fun putFloat(key: String, value: Float): SharedPreferences.Editor {
+            uncommittedPreferenceMap[key] = value
+            return this
+        }
+
+        override fun putBoolean(key: String, value: Boolean): SharedPreferences.Editor {
+            uncommittedPreferenceMap[key] = value
+            return this
+        }
+
+        override fun remove(key: String): SharedPreferences.Editor {
+            uncommittedPreferenceMap.remove(key)
+            uncommittedRemoveKeys.add(key)
+            return this
+        }
+
+        override fun clear(): SharedPreferences.Editor {
+            uncommittedRemoveKeys.clear()
+            preferenceMap.clear()
+            uncommittedPreferenceMap.clear()
+            return this
+        }
+
+        override fun commit(): Boolean {
+            uncommittedRemoveKeys.forEach {
+                preferenceMap.remove(it)
+            }
+
+            uncommittedPreferenceMap.forEach {
+                preferenceMap[it.key] = it.value
+            }
+
+            uncommittedRemoveKeys.clear()
+            uncommittedPreferenceMap.clear()
+            return true
+        }
+
+        override fun apply() {
+            commit()
+        }
+    }
+}

--- a/compass/src/main/java/com/marfeel/compass/storage/Storage.kt
+++ b/compass/src/main/java/com/marfeel/compass/storage/Storage.kt
@@ -44,7 +44,7 @@ internal class Storage(
 	 * KeyStore. Applying fallback to plain text when encryption explodes, same strategy applied by
 	 * google: https://github.com/google/tink/blob/master/java_src/src/main/java/com/google/crypto/tink/integration/android/AndroidKeysetManager.java#L101.
 	 */
-	private val preferences: SharedPreferences by lazy {
+	private val persistentPreferences: SharedPreferences by lazy {
 		try {
 			val masterKey = MasterKey.Builder(context)
 				.setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
@@ -59,6 +59,46 @@ internal class Storage(
 		} catch (_: Exception) {
 			context.getSharedPreferences(fallbackStorageName, Context.MODE_PRIVATE)
 		}
+	}
+
+	private val inMemoryPreferences: SharedPreferences by lazy { MockSharedPreference() }
+
+	private var preferences: SharedPreferences
+
+	init {
+		 preferences = togglePreferences(persistentPreferences.getBoolean(userConsent, true))
+	}
+
+	private fun togglePreferences(hasConsent: Boolean, sync: Boolean = false): SharedPreferences {
+		val oldPreferences = preferences
+		preferences = if(hasConsent) persistentPreferences else inMemoryPreferences
+
+		if (sync && oldPreferences != preferences) {
+			preferences.edit {
+				oldPreferences.all.forEach { (t, any) ->
+					if (any is String) {
+						putString(t, any)
+					} else if (any is Int) {
+						putInt(t, any)
+					} else if (any is Long) {
+						putLong(t, any)
+					} else if (any is Float) {
+						putFloat(t, any)
+					} else if (any is Boolean) {
+						putBoolean(t, any)
+					} else if (any is Set<*>) {
+						putStringSet(t, any as MutableSet<String>?)
+					}
+				}
+
+				val oldPreferencesEditor = oldPreferences.edit()
+
+				oldPreferencesEditor.clear()
+				oldPreferencesEditor.apply()
+			}
+		}
+
+		return preferences
 	}
 
 	fun updateFirstSessionTimeStamp(firstSessionTimeStamp: Long) {
@@ -284,6 +324,12 @@ internal class Storage(
 	}
 
 	fun updateUserConsent(hasConsent: Boolean) {
+		val previousUserConsent = getUserConsent()
+
+		if (previousUserConsent != hasConsent) {
+			togglePreferences(hasConsent, previousUserConsent != null)
+		}
+
 		storageScope.launch {
 			setUserConsent(hasConsent)
 		}


### PR DESCRIPTION
SharedPreferences edito doesn't allow to set variables without commiting them. On each editor retrieval content not pushed is wiped out.

Approach for user with/without consents consits in toggling between inMemoreySharedPreference mock and SharedPreference on consent change, synching previous data and clearing out previous store.