### PR TITLE
getRfv-fix-api-call

### DIFF
--- a/compass/build.gradle
+++ b/compass/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'maven-publish'
 }
 
-def compassVersion = "1.16.4"
+def compassVersion = "1.16.5"
 def apiVersion = "0.1"
 android {
     compileSdk 33

--- a/compass/src/main/java/com/marfeel/compass/network/ApiClient.kt
+++ b/compass/src/main/java/com/marfeel/compass/network/ApiClient.kt
@@ -91,11 +91,15 @@ internal class ApiClient(
 	}
 
 	fun getRfv(rfvPayloadData: RfvPayloadData): Result<RFV?> {
-		val jsonRequest = Gson().toJson(rfvPayloadData)
+		val jsonData = gson.toJsonTree(rfvPayloadData).asJsonObject
 
 		val request = Request.Builder()
-			.url("$rfvBaseUrl/$rfvPath")
-			.post(jsonRequest.toRequestBody(mediaType))
+			.url("$pingBaseUrl/data/$rfvPath")
+			.post(
+				FormBody.Builder()
+					.addJson(jsonData)
+					.build()
+			)
 			.build()
 		return try {
 			val response = httpClient.newCall(request).execute()

--- a/compass/src/test/java/com/marfeel/compass/network/ApiClientTest.kt
+++ b/compass/src/test/java/com/marfeel/compass/network/ApiClientTest.kt
@@ -80,7 +80,7 @@ class ApiClientTest {
 		enqueueApiResponse(200)
 		givenAnApiClient().getRfv(anyRfvPayloadData)
 		assertEquals(
-			"text/plain; charset=utf-8",
+			"application/x-www-form-urlencoded",
 			server.takeRequest().headers["content-type"]
 		)
 	}


### PR DESCRIPTION
getRfv was getting 404s because we were using the wrong content-type `text/plain`
<img width="286" height="199" alt="Screenshot 2026-02-09 at 15 55 51" src="https://github.com/user-attachments/assets/d461f28f-ba98-4cc4-a889-7f3288931bcc" />

sending the params as a form `application/x-www-form-urlencoded` makes it work
<img width="273" height="281" alt="Screenshot 2026-02-09 at 15 47 08" src="https://github.com/user-attachments/assets/2b195b94-6a65-4d66-a565-6c21b62a71e1" />
