### PR TITLE
fix: move configure session to onResume

### DIFF
--- a/app/src/main/java/com/marfeel/demoapp/MainScreen.kt
+++ b/app/src/main/java/com/marfeel/demoapp/MainScreen.kt
@@ -68,7 +68,6 @@ fun MainScreen(
 	val coroutineScope = CoroutineScope(Dispatchers.IO)
 
     tracker.trackScreen("main screen")
-    tracker.trackScreen("main screen")
 	tracker.setSessionVar("pepe", "pepa")
 	tracker.setSessionVar("pepe2", "pepa2")
 	tracker.setUserVar("lolo", "lola")

--- a/compass/build.gradle
+++ b/compass/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'maven-publish'
 }
 
-def compassVersion = "1.16.6"
+def compassVersion = "1.16.7"
 def apiVersion = "0.1"
 android {
     compileSdk 33

--- a/compass/src/main/java/com/marfeel/compass/core/ping/IngestPingEmitter.kt
+++ b/compass/src/main/java/com/marfeel/compass/core/ping/IngestPingEmitter.kt
@@ -12,6 +12,8 @@ internal class IngestPingEmitter(
     coroutineContext: CoroutineContext = Dispatchers.Unconfined
 ) : BackgroundWatcher {
 
+    var onResumeCallback: () -> Unit = {}
+
     private val pingFrequencyInMs = 10000L
     private val job = SupervisorJob()
     private val scope: CoroutineScope = CoroutineScope(coroutineContext + job)
@@ -71,6 +73,7 @@ internal class IngestPingEmitter(
             pingEmitterState =
                 pingEmitterState?.addTimeOnBackground(currentTimeStampInSeconds() - timeStamp)
         lastBackgroundTimeStamp = null
+        onResumeCallback()
     }
 
     override fun onPause(owner: LifecycleOwner) {

--- a/compass/src/main/java/com/marfeel/compass/core/ping/IngestPingEmitter.kt
+++ b/compass/src/main/java/com/marfeel/compass/core/ping/IngestPingEmitter.kt
@@ -25,6 +25,7 @@ internal class IngestPingEmitter(
     fun start(
         url: String,
         pageId: String,
+        sessionId: String,
         scrollPosition: Int? = null
     ) {
         stop()
@@ -33,6 +34,7 @@ internal class IngestPingEmitter(
         pingEmitterState = IngestPingEmitterState(
             url = url,
             pageId = pageId,
+            sessionId = sessionId,
             scrollPercent = scrollPosition,
             pageStartTimeStamp = currentTimeStampInSeconds(),
             timeOnBackground = 0,
@@ -85,6 +87,7 @@ internal class IngestPingEmitter(
 internal data class IngestPingEmitterState(
     val url: String,
     val pageId: String,
+    val sessionId: String,
     val scrollPercent: Int?,
     val pageStartTimeStamp: Long,
     val timeOnBackground: Long,

--- a/compass/src/main/java/com/marfeel/compass/tracker/CompassTracker.kt
+++ b/compass/src/main/java/com/marfeel/compass/tracker/CompassTracker.kt
@@ -316,7 +316,7 @@ internal object CompassTracker : CompassTracking {
         sessionStorage.clearPageVars()
         sessionStorage.clearPageMetrics()
         sessionStorage.updateRecirculationSource(rs)
-        pingEmitter.start(url, page.pageId)
+        pingEmitter.start(url, page.pageId, sessionStorage.readSession().id)
         MultimediaTracking.reset()
     }
 

--- a/compass/src/main/java/com/marfeel/compass/tracker/CompassTracker.kt
+++ b/compass/src/main/java/com/marfeel/compass/tracker/CompassTracker.kt
@@ -288,6 +288,7 @@ internal object CompassTracker : CompassTracking {
         sessionStorage.updateAccountId(accountId)
         sessionStorage.setPageTechnology(tech)
         configureSession()
+        pingEmitter.onResumeCallback = ::configureSession
     }
 
     private fun configureSession() {
@@ -310,7 +311,6 @@ internal object CompassTracker : CompassTracking {
     override fun trackNewPage(url: String, rs: String?) {
         check(initialized) { compassNotInitializedErrorMessage }
 
-        configureSession()
         val page = Page(url)
         sessionStorage.updatePage(page)
         sessionStorage.clearPageVars()

--- a/compass/src/main/java/com/marfeel/compass/usecase/IngestPing.kt
+++ b/compass/src/main/java/com/marfeel/compass/usecase/IngestPing.kt
@@ -68,7 +68,7 @@ internal class IngestPing(
 			previousUrl = pingData.previousUrl,
 			pageId = input.pageId,
 			originalUserId = pingData.originalUserId,
-			sessionId = pingData.sessionId,
+			sessionId = input.sessionId,
 			pingCounter = null,
 			currentTimeStamp = pingData.currentTimeStamp,
 			userType = pingData.userType,


### PR DESCRIPTION
  # Problem                                                                                                                      
                                                                                                                             
  When clients call trackNewPage twice in quick succession in different threads (e.g. first without recirculation source, then with it), both calls 
  race through configureSession(). Both read storage.readSession() as null/stale before either writes, creating two separate sessions per app open.

  This results in ~2x inflated session counts, ghost sessions with incomplete data (no page metadata, RefEditorialID=0), and skewed engagement/RFV metrics.

  The previous fix (session race conditions on simultaneous calls #36) addressed ping-level races with the pageId guard but didn't prevent duplicate session creation.

  # Changes

  - Remove configureSession() from trackNewPage() — page tracking no longer touches session state, eliminating the race
  entirely
  - Add onResumeCallback to IngestPingEmitter — generic lifecycle hook so the tracker can inject behavior on app resume
  - Tracker injects configureSession as the resume callback — session renewal after 30+ min in background is handled via the
  emitter's existing lifecycle, keeping session logic in the tracker
  - Remove duplicate trackScreen call in demo app

  # How it works

  - Session is created/renewed at initialize() (once per app start)
  - Session is renewed on app resume via the emitter's onResume → callback → configureSession()
  - trackNewPage only handles page tracking — safe to call concurrently from any thread