### PR TITLE
fix: idempotent configureSession to stop double session rotation 

### DIFF
--- a/compass/build.gradle
+++ b/compass/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'maven-publish'
 }
 
-def compassVersion = "1.16.8"
+def compassVersion = "1.16.9"
 def apiVersion = "0.1"
 android {
     compileSdk 33

--- a/compass/src/main/java/com/marfeel/compass/tracker/CompassTracker.kt
+++ b/compass/src/main/java/com/marfeel/compass/tracker/CompassTracker.kt
@@ -292,13 +292,14 @@ internal object CompassTracker : CompassTracking {
     }
 
     private fun configureSession() {
-        val lastPing = storage.readLastPingTimeStamp()
-        if (lastPing == null) {
-            val session = storage.readSession()
-            if (session == null || session.timeStamp < thirtyMinsAgoInSeconds()) {
-                sessionStorage.updateSession()
-            }
-        } else if (lastPing < thirtyMinsAgoInSeconds()) {
+        val session = storage.readSession()
+        if (session == null) {
+            sessionStorage.updateSession()
+            return
+        }
+        val lastPing = storage.readLastPingTimeStamp() ?: 0L
+        val lastActivity = maxOf(session.timeStamp, lastPing)
+        if (lastActivity < thirtyMinsAgoInSeconds()) {
             sessionStorage.updateSession()
         }
     }

--- a/compass/src/test/java/com/marfeel/compass/tracker/CompassTrackerSessionTest.kt
+++ b/compass/src/test/java/com/marfeel/compass/tracker/CompassTrackerSessionTest.kt
@@ -1,0 +1,63 @@
+package com.marfeel.compass.tracker
+
+import com.marfeel.compass.core.model.compass.Session
+import com.marfeel.compass.core.model.compass.currentTimeStampInSeconds
+import com.marfeel.compass.core.ping.IngestPingEmitter
+import com.marfeel.compass.di.CompassComponent
+import com.marfeel.compass.network.ApiClient
+import com.marfeel.compass.storage.SessionStorage
+import com.marfeel.compass.storage.Storage
+import com.marfeel.compass.usecase.IngestPing
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import junit.framework.TestCase.assertEquals
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+
+internal class CompassTrackerSessionTest {
+
+	private val storage = mockk<Storage>(relaxed = true)
+	private val apiClient = mockk<ApiClient>(relaxed = true)
+	private val sessionStorageInstance = SessionStorage(storage)
+	private val ingestPing = IngestPing(apiClient, sessionStorageInstance, storage)
+	private val pingEmitter = IngestPingEmitter(ingestPing)
+	private val sessionHolder = AtomicReference<Session?>(null)
+
+	@Before
+	fun setup() {
+		val stale = currentTimeStampInSeconds() - 40 * 60
+		sessionHolder.set(Session(UUID.randomUUID().toString(), stale))
+
+		every { storage.readSession() } answers { sessionHolder.get() }
+		every { storage.setSession(any()) } answers {
+			sessionHolder.set(firstArg())
+		}
+		every { storage.readLastPingTimeStamp() } returns stale
+
+		mockkObject(CompassComponent)
+		every { CompassComponent.storage } returns storage
+		every { CompassComponent.sessionStorage } returns sessionStorageInstance
+		every { CompassComponent.ingestPingEmitter } returns pingEmitter
+	}
+
+	@After
+	fun tearDown() {
+		unmockkObject(CompassComponent)
+	}
+
+	@Test
+	fun `onResume right after initialize does not rotate session a second time`() {
+		CompassTracker.initialize("acct-id", 4)
+		val sessionAfterInit = sessionHolder.get()!!.id
+
+		pingEmitter.onResumeCallback.invoke()
+		val sessionAfterResume = sessionHolder.get()!!.id
+
+		assertEquals(sessionAfterInit, sessionAfterResume)
+	}
+}


### PR DESCRIPTION

## Summary

Fixes a regression introduced in 1.16.7 (PR #42, `f8613f2`) that causes **extra `SessionID` rotations during the same user activity window**, producing phantom sessions on the server side. After this fix, consecutive pageviews within one continuous ping stream inherit the same `SessionID`, matching the 1.16.3 / 1.16.6 baseline.

Observed on production (ANM, last 30 days):

| metric | 1.16.3 | 1.16.7 |
|---|---|---|
| `visits_by_SessionID` | 3041 | 5309 |
| `visits_by_20min_gap` | 2298 | 3231 |
| **`sessionID / 20min_gap` ratio** | **1.32** | **1.64** |
| `DIFF_SESS` (phantoms) | 743 | 2078 |

Each "real" (20-min-inactive) visit is currently carrying ~1.64 sessionIDs on 1.16.7 vs ~1.32 on 1.16.3. That's roughly **+1335 phantom rotations per 30 days** attributable to PR #42 behavior.

---

## Root cause

`CompassTracker.configureSession()` is not idempotent. Two back-to-back calls with a stale `lastPingTimeStamp` in storage produce two rotations.

`SessionStorage.updateSession()` archives `lastPingTimeStamp` into `previousSessionLastPingTimeStamp` but **does not reset** the live `lastPingTimeStamp`. Until the next ping actually runs and updates it (`IngestPing.kt:39`), any additional call to `configureSession()` sees the same stale value and rotates again.

PR #42 added two new call sites that can fire back-to-back before a ping has a chance to run:

1. `CompassTracker.initialize()` → `configureSession()` (`CompassTracker.kt:290`)
2. `pingEmitter.onResumeCallback = ::configureSession` → fires on every `ProcessLifecycleOwner.onResume` (`CompassTracker.kt:291`)

### Reproduction trace (cold start after ≥ 30 min absence)

| t | event | storage session | `lastPingTimeStamp` | emitter |
|---|---|---|---|---|
| 0 | process was dead 40 min; storage has `S1` + stale lastPing | `S1` | 40 min ago | — |
| t | push tap → `Application.onCreate` → `CompassTracking.initialize(...)` → `configureSession()` | `S1 → S2` | 40 min ago (**unchanged**) | — |
| t | `trackNewPage(articleA, rs="push")` → `pingEmitter.start(..., S2)` | `S2` | 40 min ago | frozen with `S2` |
| t + ε | `ProcessLifecycleOwner.onResume` → `onResumeCallback()` → `configureSession()` | `S2 → S3` | 40 min ago (still) | still frozen with `S2` |
| t + 10 s | first ping fires carrying `S2`; `lastPingTimeStamp` updated to now | `S3` | now | `S2` |
| later | user navigates → `trackNewPage(articleB)` → `pingEmitter.start(..., S3)` | `S3` | — | frozen with `S3` |

Result: article A pings emit `S2`, article B pings emit `S3`, **within a single continuous activity window**. Server sees a sessionID transition with no real inactivity gap → phantom session on the dashboard.

The bug is observable on 1.16.7 (and not on 1.16.6) because PR #42 also introduced sticky-sessionID-per-pageview in `IngestPingEmitterState`. Pre-PR-#42 the extra rotation also happened in storage, but pings re-read session from storage each tick, so by the time the first ping fired the "winning" session was already the latest one and nothing transitioned mid-stream. The sticky fix is correct and is kept.

---

## The fix

`CompassTracker.configureSession()` now uses the session's own `timeStamp` as activity evidence alongside `lastPingTimeStamp`. A freshly rotated session is itself proof that the 30-minute window has been reset, so repeated calls in quick succession become no-ops.

```kotlin
private fun configureSession() {
    val session = storage.readSession()
    if (session == null) {
        sessionStorage.updateSession()
        return
    }
    val lastPing = storage.readLastPingTimeStamp() ?: 0L
    val lastActivity = maxOf(session.timeStamp, lastPing)
    if (lastActivity < thirtyMinsAgoInSeconds()) {
        sessionStorage.updateSession()
    }
}
```

### Properties

- **Idempotent.** After a rotation, `session.timeStamp == now` → `lastActivity` is fresh regardless of whatever stale value `lastPingTimeStamp` still holds. Cascade broken at the root.
- **PR #42 sticky-sessionID preserved.** `IngestPingEmitterState` continues to freeze the sessionID per pageview at `pingEmitter.start(...)` time. One session per pageview at the ping level holds.
- **PR #42 intent preserved.** A genuine ≥ 30 min background followed by `onResume` still rotates the session exactly once, even without a `trackNewPage` call.
- **`lastPingTimeStamp` semantics unchanged.** Only `IngestPing` writes it when a ping actually fires. `previousSessionLastPingTimeStamp` continues to reflect the real last ping of the previous session.
- **First-run path preserved.** When storage has no session (fresh install), the `session == null` branch creates one.

---

## Alternatives considered

- **Full revert of PR #42.** Would also lose the sticky-sessionID-per-pageview fix, re-introducing the pre-PR-#42 "one pageview, pings with different sessionIDs mid-stream" shape.
- **Partial revert:** keep sticky sessionID, remove `onResumeCallback` wire-up, put `configureSession` back in `trackNewPage`. Loses PR #42's intent of rotating on resume after long background without user navigation. Not proposed here but would be a reasonable follow-up if production data after this fix shows the remaining resume-rotation behavior is undesired.
- **Gate `onResumeCallback` by background duration ≥ 30 min.** Doesn't fix the root cause; duplicates the 30-min threshold across two files. Not needed once `configureSession()` is idempotent. Optional future hardening.

---

## Testing

New test: `compass/src/test/java/com/marfeel/compass/tracker/CompassTrackerSessionTest.kt`.

Seeds a stale session + stale `lastPingTimeStamp` (40 min old), drives `CompassTracker.initialize(...)`, then invokes the wired `onResumeCallback`, and asserts the session UUID is unchanged.

- **On 1.16.7 (current develop)**: `junit.framework.ComparisonFailure: expected:<[785412b4…]> but was:<[9ced6ab2…]>` — two rotations occurred.
- **With this fix**: passes.

Full suite: `./gradlew :compass:test` → BUILD SUCCESSFUL (both `viewsUi` and `composeUi` flavors, debug + release). No pre-existing tests regressed.

### Test isolation note

The test mocks `CompassComponent` and exercises the `CompassTracker` singleton's `lazy`-cached dependencies. It must be the only test in its JVM run that touches `CompassTracker`. Future `CompassTracker` tests will need their own isolation (fork-per-test via Gradle, or reflection-based `lazy` reset). Only relevant if/when additional `CompassTracker` tests are added.

---

## Rollout plan

1. Merge, release as **1.16.9** to Nexus (`compassVersion` bumped in `compass/build.gradle`).
2. Monitor the "Visits Logs vs DSF per UA" dashboard for UA `Marfeel-Android-SDK/1.16.9` over one week post-rollout.
3. Expected signal: `sessionID / 20min_gap` ratio drops from **1.64** toward **1.32** (1.16.3 baseline).

Interpretation guide for post-rollout data:

- **Ratio drops to ~1.32–1.40** → fix fully resolved the regression. Ship as-is.
- **Ratio drops to ~1.45–1.55** → cascade was the dominant bug; residual delta is PR #42's intentional rotate-on-resume-after-long-bg behavior (kept by this PR). Open a separate discussion on whether to also remove the `onResumeCallback` wire-up.
- **Ratio stays near 1.64** → a second mechanism exists that this fix didn't catch. Would reopen investigation; the PR #42 diff suggests nothing else obvious, but empirical behavior takes precedence.

---

## Files changed

- `compass/src/main/java/com/marfeel/compass/tracker/CompassTracker.kt` — `configureSession()` rewritten to use `maxOf(session.timeStamp, lastPing)` as the idle-signal guard.
- `compass/src/test/java/com/marfeel/compass/tracker/CompassTrackerSessionTest.kt` — new regression test.
- `compass/build.gradle` — `compassVersion` → `1.16.9`.

## Risk

Low. The change narrows when `configureSession()` rotates; it never rotates in cases where the old logic did not. A freshly-created session is treated as equivalent evidence of activity as a recent ping — which is already true by construction (`newSession()` sets `timeStamp = currentTimeStampInSeconds()`). No public API change; no storage schema change; no network wire change.

## Test plan (for reviewers)

- [ ] Review the `configureSession()` rewrite against the trace table above.
- [ ] Run `./gradlew :compass:test`; confirm BUILD SUCCESSFUL.
- [ ] Run the single reproduction test against `develop` (pre-fix) to confirm it fails, then against this branch to confirm it passes.
- [ ] Verify `compass/build.gradle` version bump is correct.
- [ ] (Optional) Smoke-test sample app: open app, background for 31+ min, return, navigate to a new page — confirm exactly one `SessionID` transition in emitted pings.
